### PR TITLE
Improve cards for mobile users

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -70,65 +70,75 @@ const Card = (props: CardProps) => {
       </div>
       <h2 className="sr-only">{title}</h2>
       {currentSeason?.title && (
-        <div
-          aria-label={`Current ${seasonKeyword}`}
-          className="flex flex-col gap-1"
-        >
-          <div className="flex flex-row gap-2">
-            <span className="sr-only">{`What is the current ${title} ${seasonKeyword}?`}</span>
-            <div className="flex flex-col md:flex-row md:gap-2">
-              <div className="md:my-auto">
-                <Chip className="!bg-slate-500">Now</Chip>
-              </div>
-              <h3 className="text-lg font-semibold">
-                <a
-                  href={currentSeason.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {currentSeason.title}
-                </a>
-              </h3>
-              {shortName && (
-                <span className="sr-only">{`${shortName} ${currentSeason.title} ${seasonKeyword}`}</span>
-              )}
-            </div>
-          </div>
-          <div className="flex flex-row justify-between">
-            <div className="flex flex-col gap-1 col-span-4">
-              <span className="sr-only">{`When did the current ${title} ${seasonKeyword} start?`}</span>
-              <div className="flex flex-row gap-2 text-sm">
-                {!!currentSeason.startDateNotice || !currentSeason.startDate ? (
-                  <span>{currentSeason.startDateNotice}</span>
-                ) : (
-                  <div>
-                    {shortName && (
-                      <span className="sr-only">{`${shortName} ${currentSeason.title} ${seasonKeyword} release date`}</span>
-                    )}
-                    <LocalDate utcDate={currentSeason.startDate} />
+        <>
+          <div
+            aria-label={`Current ${seasonKeyword}`}
+            className="flex flex-col gap-1"
+          >
+            <div className="gap-4 sm:gap-1 flex sm:flex-col max-sm:items-center">
+              <div className="flex flex-row gap-2 flex-1">
+                <span className="sr-only">{`What is the current ${title} ${seasonKeyword}?`}</span>
+                <div className="flex flex-col md:flex-row md:gap-2">
+                  <div className="md:my-auto hidden sm:block">
+                    <Chip className="!bg-slate-500">Now</Chip>
                   </div>
-                )}
+                  <h3 className="text-base sm:text-lg font-semibold">
+                    <a
+                      href={currentSeason.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {currentSeason.title}
+                    </a>
+                  </h3>
+                  {shortName && (
+                    <span className="sr-only">{`${shortName} ${currentSeason.title} ${seasonKeyword}`}</span>
+                  )}
+                </div>
+              </div>
+              <div className="flex flex-row justify-end sm:justify-between">
+                <div className="flex-col gap-1 col-span-4 hidden sm:flex">
+                  <span className="sr-only">{`When did the current ${title} ${seasonKeyword} start?`}</span>
+                  <div className="flex flex-row gap-2 text-sm">
+                    {!!currentSeason.startDateNotice || !currentSeason.startDate ? (
+                      <span>{currentSeason.startDateNotice}</span>
+                    ) : (
+                      <div>
+                        {shortName && (
+                          <span className="sr-only">{`${shortName} ${currentSeason.title} ${seasonKeyword} release date`}</span>
+                        )}
+                        <LocalDate utcDate={currentSeason.startDate} />
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <div>
+                  <span className="sr-only">{`When is the current ${title} ${seasonKeyword} ending?`}</span>
+                  <div className="flex flex-row-reverse gap-2 text-sm">
+                    {!!currentSeason.endDateNotice || !currentSeason.endDate ? (
+                      <span>{currentSeason.endDateNotice}</span>
+                    ) : (
+                      <LocalDate utcDate={currentSeason.endDate} dateOnly />
+                    )}
+                  </div>
+                </div>
               </div>
             </div>
-            <div>
-              <span className="sr-only">{`When is the current ${title} ${seasonKeyword} ending?`}</span>
-              <div className="flex flex-row-reverse gap-2 text-sm">
-                {!!currentSeason.endDateNotice || !currentSeason.endDate ? (
-                  <span>{currentSeason.endDateNotice}</span>
-                ) : (
-                  <LocalDate utcDate={currentSeason.endDate} dateOnly />
-                )}
+            <div className="flex w-full items-center gap-1">
+              <Chip className="!bg-slate-500 sm:hidden">Now</Chip>
+              <div className="flex-1">
+                <ProgressBar
+                  progress={getProgress(
+                    currentSeason?.startDate,
+                    currentSeason?.endDate,
+                    props.testProps?.now,
+                  )}
+                  />
               </div>
             </div>
           </div>
-          <ProgressBar
-            progress={getProgress(
-              currentSeason?.startDate,
-              currentSeason?.endDate,
-              props.testProps?.now,
-            )}
-          />
-        </div>
+          <hr className="sm:hidden my-1 border-gray-200/80"/>
+        </>
       )}
       {nextSeason?.title && (
         <div
@@ -138,10 +148,10 @@ const Card = (props: CardProps) => {
           <div className="flex flex-row gap-2 justify-between">
             <span className="sr-only">{`What is the next ${title} ${seasonKeyword}?`}</span>
             <div className="flex flex-col md:flex-row md:gap-2">
-              <div className="md:my-auto">
+              <div className="md:my-auto hidden sm:block">
                 <Chip>Next</Chip>
               </div>
-              <h3 className="text-lg font-semibold">
+              <h3 className="text-base sm:text-lg font-semibold">
                 <a
                   href={nextSeason.url}
                   target="_blank"
@@ -155,7 +165,7 @@ const Card = (props: CardProps) => {
               )}
             </div>
             {!!nextSeason.startDate && (
-              <div className="mt-auto">
+              <div className="mt-auto max-sm:flex">
                 <GoogleCalendarButton
                   title={`${title} ${seasonKeyword} start`}
                   date={new Date(nextSeason.startDate)}
@@ -163,16 +173,20 @@ const Card = (props: CardProps) => {
               </div>
             )}
           </div>
-          <div className="flex flex-row justify-between items-baseline min-h-[28px]">
+          <div className="flex flex-row justify-between sm:items-baseline min-h-[28px]">
             <span className="sr-only">{`When is the next ${title} ${seasonKeyword} starting?`}</span>
             <div className="flex flex-row gap-2 text-sm">
               {!!nextSeason.startDateNotice || !nextSeason.startDate ? (
-                <span>{nextSeason.startDateNotice}</span>
+                <div className="gap-1 flex items-center">
+                  <Chip className="sm:hidden">Next</Chip>
+                  <span>{nextSeason.startDateNotice}</span>
+                </div>
               ) : (
-                <div>
+                <div className="gap-1 flex items-center">
                   {shortName && (
                     <span className="sr-only">{`${shortName} ${nextSeason.title} ${seasonKeyword} release date`}</span>
                   )}
+                  <Chip className="sm:hidden">Next</Chip>
                   <LocalDate utcDate={nextSeason.startDate} />
                 </div>
               )}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -75,7 +75,7 @@ const Card = (props: CardProps) => {
             aria-label={`Current ${seasonKeyword}`}
             className="flex flex-col gap-1"
           >
-            <div className="gap-4 sm:gap-1 flex sm:flex-col max-sm:items-center">
+            <div className="gap-4 sm:gap-1 flex sm:flex-col max-sm:items-end">
               <div className="flex flex-row gap-2 flex-1">
                 <span className="sr-only">{`What is the current ${title} ${seasonKeyword}?`}</span>
                 <div className="flex flex-col md:flex-row md:gap-2">
@@ -114,7 +114,7 @@ const Card = (props: CardProps) => {
                 </div>
                 <div>
                   <span className="sr-only">{`When is the current ${title} ${seasonKeyword} ending?`}</span>
-                  <div className="flex flex-row-reverse gap-2 text-sm">
+                  <div className="flex flex-row-reverse gap-2 text-sm max-sm:leading-6">
                     {!!currentSeason.endDateNotice || !currentSeason.endDate ? (
                       <span>{currentSeason.endDateNotice}</span>
                     ) : (


### PR DESCRIPTION
Changed the way cards look until `sm` breakpoint for mobile users.

Card with exact date of next cycle:
![image](https://github.com/AyronK/arpg-timeline/assets/62035747/76ea3d93-c6c1-44d5-ab5e-765238247fde)

Card with estimated date of next cycle:
![image](https://github.com/AyronK/arpg-timeline/assets/62035747/ad5253f3-b8cd-4356-bb0d-a46612a80fee)

Wrapping of the the date and countdown if they're too long (this could be changed by, for example, flex wrapping the chip and date or flex wrapping the countdown under those two, but it wouldn't look like the other cards so I think it should just be left like this):
![image](https://github.com/AyronK/arpg-timeline/assets/62035747/35f553bb-55d2-4b75-adfb-a89834250e17)


Layout remains the same as before after `sm`.
The gap between the green chip and the date may be shorter than the one in the second picture of #51 , but it's the same as the gap between the gray chip and progress bar (which is the same as in the picture).

Let me know if I should change something else.