### PR TITLE
Adds a two day grace period for freshly launched seasons and crawler to get notifications

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -2,6 +2,8 @@ name: Crawl sources and notify Discord
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: 0 0 * * *
 
 jobs:
   check-and-notify:

--- a/src/components/SeasonCard.tsx
+++ b/src/components/SeasonCard.tsx
@@ -18,6 +18,7 @@ type SeasonCardProps = Partial<{
     url: string;
     startDateNotice: string;
     endDateNotice: string;
+    justStarted?: boolean;
   }>;
   nextSeason: Partial<{
     startDate: string;
@@ -149,7 +150,13 @@ const CurrentSeasonWidget = ({
           <span className="sr-only">{`What is the current ${title} ${seasonKeyword}?`}</span>
           <div className="flex flex-col md:flex-row md:gap-2 min-w-0">
             <div className="hidden sm:block">
-              <Chip className="!bg-slate-500">Now</Chip>
+              <Chip
+                className={
+                  currentSeason.justStarted ? "!bg-blue-500" : "!bg-slate-500"
+                }
+              >
+                {currentSeason.justStarted ? "LIVE" : "Now"}
+              </Chip>
             </div>
             <h3
               className="text-base sm:text-lg font-semibold flex-1 md:line-clamp-1"
@@ -179,7 +186,7 @@ const CurrentSeasonWidget = ({
                   {shortName && (
                     <span className="sr-only">{`${shortName} ${currentSeason.title} ${seasonKeyword} release date`}</span>
                   )}
-                  <LocalDate utcDate={currentSeason.startDate} />
+                  <LocalDate utcDate={currentSeason.startDate} dateOnly />
                 </div>
               )}
             </div>
@@ -199,7 +206,15 @@ const CurrentSeasonWidget = ({
         </div>
       </div>
       <div className="flex w-full items-center gap-1">
-        <Chip className="!bg-slate-500 sm:hidden">Now</Chip>
+        <Chip
+          className={
+            currentSeason.justStarted
+              ? "!bg-blue-500 sm:hidden"
+              : "!bg-slate-500 sm:hidden"
+          }
+        >
+          {currentSeason.justStarted ? "LIVE" : "Now"}
+        </Chip>
         <div className="flex-1">
           <ProgressBar
             progress={getProgress(
@@ -249,13 +264,15 @@ const SeasonCard = (props: SeasonCardProps) => {
         testProps={props.testProps}
         seasonKeyword={seasonKeyword}
       />
-      <NextSearsonWidget
-        nextSeason={nextSeason}
-        title={title}
-        shortName={shortName}
-        testProps={props.testProps}
-        seasonKeyword={seasonKeyword}
-      />
+      {!currentSeason?.justStarted && (
+        <NextSearsonWidget
+          nextSeason={nextSeason}
+          title={title}
+          shortName={shortName}
+          testProps={props.testProps}
+          seasonKeyword={seasonKeyword}
+        />
+      )}
     </section>
   );
 };

--- a/src/pages/games/path-of-exile.md
+++ b/src/pages/games/path-of-exile.md
@@ -18,4 +18,7 @@ nextSeason:
   url: ""
   showCountdown: true
   startDate: 2024-07-26T20:00:00.000Z
+crawlerSettings:
+  keywords: ["3.25"]
+  sources: ["https://poedb.tw/us/"]
 ---


### PR DESCRIPTION
1. Adds a two day grace period for freshly launched seasons, partially implementing #79 (but code is 💩)
2. Adds crawler that generates notification based on game sources and keywords
3. Added schedule to run crawler everyday